### PR TITLE
Enhancement arguments

### DIFF
--- a/dotnet-philly/Attributes/ValidationAttributes.cs
+++ b/dotnet-philly/Attributes/ValidationAttributes.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+
+namespace dotnet_philly.Attributes
+{
+    public class IsValidUrlAttribute : ValidationAttribute
+    {
+        public IsValidUrlAttribute() : base("{0} must be a valid http or https URL. Example: https://localhost:5001/Samples") { }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var valid = Uri.TryCreate(value.ToString(), UriKind.Absolute, out Uri result) && (result.Scheme == "http" || result.Scheme == "https");
+            if (!valid)
+            {
+                return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/dotnet-philly/Startup/ConfigureConfiguration.cs
+++ b/dotnet-philly/Startup/ConfigureConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace dotnet_philly.Startup
+{
+    internal static class ConfigureConfiguration
+    {
+        internal static IConfiguration Execute()
+        {
+            return new ConfigurationBuilder()
+                .AddJsonFile($"appsettings.json", true, true)
+                .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DotNet_Environment")}.json", true, true)
+                // ApplicationData results in the following paths:
+                // Windows: <UserProfile>/AppData/Roaming
+                // Mac:     /Users/<user>/.config
+                // Linux:   /home/<user>/.config
+                .AddJsonFile($"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}/dotnet-philly/appsettings.json", true, true)
+                .Build();
+        }
+    }
+}

--- a/dotnet-philly/Startup/ConfigureServices.cs
+++ b/dotnet-philly/Startup/ConfigureServices.cs
@@ -1,0 +1,25 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace dotnet_philly.Startup
+{
+    internal static class ConfigureServices
+    {
+        internal static IServiceProvider Execute(ServiceCollection services, IConfiguration configuration)
+        {
+            services.AddLogging(config => {
+                config.AddConfiguration(configuration.GetSection("Logging"));
+                config.AddConsole();
+                config.AddDebug();
+            });
+            services.AddSingleton<IConsole>(PhysicalConsole.Singleton);
+
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/dotnet-philly/appsettings.Development.json
+++ b/dotnet-philly/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "RegistryUri": "https://localhost:5001/Samples",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/dotnet-philly/appsettings.json
+++ b/dotnet-philly/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "RegistryUri": "<<ADD DEFAULT URI>>",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}

--- a/dotnet-philly/dotnet-philly.csproj
+++ b/dotnet-philly/dotnet-philly.csproj
@@ -5,10 +5,22 @@
     <PackAsTool>True</PackAsTool>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>dotnet_philly</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings.Development.json" />
+    <None Remove="appsettings.json" />
     <None Remove="DotnetToolSettings.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -17,9 +29,12 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
I refactored the OutputFolder attribute to be an option instead of an argument to bring it inline with other dotnet global tools.

Additionally, I added a SamplesSource option that will allow you to override the repository catalog url from the command line.